### PR TITLE
fix the CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6.15', '3.9.18', '3.12.0']
+        python-version: ['3.7', '3.8', '3.9.18', '3.10', '3.11', '3.12.0']
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -19,11 +19,31 @@ jobs:
         run: pip install -r requirements/test.txt
       - name: Run unit tests
         run: python -m tests -v
+
+  # due to error: "The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04."
+  # test for python 3.6 is run on ubuntu 20.04
+  unit-3_6: # can't use 3.6 as job name
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install -r requirements/test.txt
+      - name: Run unit tests
+        run: python -m tests -v
+
   style:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6.15']
+        python-version: ['3.7']
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,4 +6,4 @@ requests==2.26.0
 urllib3==1.26.6
 coverage==5.5
 hypothesis==6.14.3
-flake8==3.9.2
+flake8==5.0.4


### PR DESCRIPTION
_I'm sorry in advance that this comes without an issue_
_It seems this has been discussed in some of the latest issues, and there's no point in opening another one_

### Fixing the CI:
- adding py versions up to 3.12
- to keep support for 3.6, a few steps had to be taken: 
    - The flake test runs with 3.7 due to Flake's unresolved dependency issue.
    - Flake bumped to the highest version that can run on 3.7 (instead of the latest, which is not compatible with py 3.7)
    - due to a lack of image for py 3.6 with ubuntu-latest, the unit test for py 3.6 runs in a dedicated job on ubuntu 20.04