### PR TITLE
closes #53 dependencies bump

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,26 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9.18', '3.10', '3.11', '3.12.0']
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install -r requirements/test.txt
-      - name: Run unit tests
-        run: python -m tests -v
-
-  # due to error: "The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04."
-  # test for python 3.6 is run on ubuntu 20.04
-  unit-3_6: # can't use 3.6 as job name
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.6']
+        python-version: ['3.8', '3.9.18', '3.10', '3.11', '3.12.0']
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -43,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.8']
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 certifi==2023.11.17
-chardet==5.0.0
+chardet==5.2.0
 idna==3.6
-requests==2.27.1
-urllib3==1.26.18
-isort~=5.9
-pre-commit~=2.13.0
+requests==2.31.1
+urllib3==2.1.0
+isort~=5.13.1
+pre-commit~=3.5.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
-certifi==2023.7.22
-chardet==4.0.0
-idna==3.2
-requests==2.26.0
-urllib3==1.26.6
+certifi==2023.11.17
+chardet==5.0.0
+idna==3.6
+requests==2.27.1
+urllib3==1.26.18
 isort~=5.9
 pre-commit~=2.13.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,9 @@
-attrs==21.2.0
-certifi==2023.7.22
-chardet==4.0.0
-idna==3.2
-requests==2.26.0
-urllib3==1.26.6
-coverage==5.5
-hypothesis==6.14.3
+attrs==22.2.0
+certifi==2023.11.17
+chardet==5.0.0
+idna==3.6
+requests==2.27.1
+urllib3==1.26.18
+coverage==6.2
+hypothesis==6.31.6
 flake8==5.0.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,9 @@
-attrs==22.2.0
+attrs==23.1.0
 certifi==2023.11.17
-chardet==5.0.0
+chardet==5.2.0
 idna==3.6
-requests==2.27.1
-urllib3==1.26.18
-coverage==6.2
-hypothesis==6.31.6
-flake8==5.0.4
+requests==2.31.0
+urllib3==2.1.0
+coverage==7.3.2
+hypothesis==6.92.0
+flake8==6.1.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme_text():
 setuptools.setup(
     name='pokebase',
     packages=['pokebase'],
-    version='1.3.1',
+    version='1.4.0',
     description='A Python wrapper for the friendly PokeAPI database',
     long_description=readme_text(),
     author='Greg Hilmes',
@@ -20,8 +20,6 @@ setuptools.setup(
     license='BSD License',
     classifiers=[
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
As written in the issue log, the support for 3.6-7 is very limiting; 
hence so few version bumps are possible without running into dependencies nightmares. 